### PR TITLE
Fix Frends.Tasks.Attributes reference to a working version (1.2.1)

### DIFF
--- a/Frends.Xml/Frends.Xml.csproj
+++ b/Frends.Xml/Frends.Xml.csproj
@@ -33,8 +33,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Frends.Tasks.Attributes, Version=1.2.0.0, Culture=neutral, PublicKeyToken=258fd606323928fc, processorArchitecture=MSIL">
-      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.0\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Frends.Tasks.Attributes.1.2.1\lib\net40\Frends.Tasks.Attributes.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Frends.Xml/packages.config
+++ b/Frends.Xml/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Frends.Tasks.Attributes" version="1.2.0" targetFramework="net452" />
+  <package id="Frends.Tasks.Attributes" version="1.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net452" />
   <package id="Saxon-HE" version="9.7.0.14" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -3,24 +3,11 @@
    - [Building](#building)
    - [Contributing](#contributing)
    - [Documentation](#documentation)
-     - [Xml.XpathQuery](#xml.xpathquery)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Xml.XpathQuerySingle](#xml.xpathquerysingle)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Xml.Transform](#xml.transform)
-       - [Input](#input)
-       - [Result](#result)
-     - [Xml.Validate](#xml.validate)
-       - [Input](#input)
-       - [Options](#options)
-       - [Result](#result)
-     - [Xml.ConvertJsonToXml](#xml.convertjsontoxml)
-       - [Input](#input)
-       - [Result](#result)
+     - [Xml.XpathQuery](#xmlxpathquery) 
+     - [Xml.XpathQuerySingle](#xmlxpathquerysingle)
+     - [Xml.Transform](#xmltransform)
+     - [Xml.Validate](#xmlvalidate)
+     - [Xml.ConvertJsonToXml](#xmlconvertjsontoxml)
    - [License](#license)
    
 # Frends.Xml
@@ -31,8 +18,6 @@ You can install the task via FRENDS UI Task view or you can find the nuget packa
 `https://www.myget.org/F/frends/api/v2`
 
 ## Building
-Ensure that you have `https://www.myget.org/F/frends/api/v2` added to your nuget feeds
-
 Clone a copy of the repo
 
 `git clone https://github.com/FrendsPlatform/Frends.Xml.git`

--- a/nuspec/Frends.Xml.nuspec
+++ b/nuspec/Frends.Xml.nuspec
@@ -10,7 +10,6 @@
     <description>FRENDS Xml tasks</description>
     <summary />
     <dependencies>
-	    <dependency id="Frends.Tasks.Attributes" version="1.2.0" />
       <dependency id="Newtonsoft.Json" version="6.0.8" />
       <dependency id="Saxon-HE" version="[9.7.0.14]" />
     </dependencies>
@@ -20,7 +19,7 @@
     </frameworkAssemblies>
   </metadata>
   <files>
-	<file src="Frends.Xml\bin\Release\Frends.Xml.dll" target="lib\net452\Frends.Xml.dll" />	
+	<file src="Frends.Xml\bin\Release\Frends.Xml.dll" target="lib\net452\Frends.Xml.dll" />
     <file src="Frends.Xml\bin\Release\Frends.Xml.XML" target="Frends.Xml.XML"/>
     <file src="Frends.Xml\FrendsTaskMetadata.json" target="FrendsTaskMetadata.json"/>
   </files>


### PR DESCRIPTION
Version 1.2.0 cannot be used as it has the wrong assembly version, so compilation will fail.