### PR TITLE
Fixing XSLT encoding problems

### DIFF
--- a/Frends.Xml.Tests/Tests.cs
+++ b/Frends.Xml.Tests/Tests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
-using System.Text;
 
 namespace Frends.Xml.Tests
 {
@@ -116,8 +115,7 @@ namespace Frends.Xml.Tests
             Assert.That(((JToken)jTokenRes[1])["price"].Value<string>(), Is.EqualTo("11.99"));
             Assert.That(((JToken)jTokenRes[2])["price"].Value<string>(), Is.EqualTo("9.99"));
         }
-
-        //TODO: Add test for XsltTransformParameters
+        
         [Test]
         public void TestXsltTransform()
         {
@@ -138,7 +136,6 @@ namespace Frends.Xml.Tests
             Assert.That(res, Is.EqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?>Hello, World!<DIV>from <I>An XSLT Programmer</I></DIV>"));
         }
 
-
         [Test]
         public void TestXsltTransformWithNonUTF8Declaration()
         {
@@ -154,6 +151,41 @@ namespace Frends.Xml.Tests
 
             var res = Frends.Xml.Xml.Transform(new TransformInput() { Xml = transformXml, Xslt = xslt });
             Assert.That(res, Is.EqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><out>Ä</out>"));
+        }
+
+        [Test]
+        public void TestXsltTransformWithWhiteSpaces()
+        {
+            string transformXml = String.Format(@"<?xml version=""1.0"" encoding=""utf-8"" ?><in>foo  {0}{0}bar</in>", Environment.NewLine);
+
+            const string xslt = @"<?xml version=""1.0""?>
+                                <xsl:stylesheet xmlns:xsl=""http://www.w3.org/1999/XSL/Transform"" version=""2.0"">
+                                <xsl:output method=""xml"" />
+                                  <xsl:template match=""/in"">
+                                       <out><xsl:value-of select="".""/></out>
+                                  </xsl:template>
+                                </xsl:stylesheet>";
+
+            var res = Frends.Xml.Xml.Transform(new TransformInput() { Xml = transformXml, Xslt = xslt });
+            Assert.That(res, Is.EqualTo(String.Format("<?xml version=\"1.0\" encoding=\"UTF-8\"?><out>foo  {0}{0}bar</out>", Environment.NewLine)));
+        }
+
+        [Test]
+        public void TestXsltTransformWithParams()
+        {
+            string transformXml = String.Format(@"<?xml version=""1.0"" encoding=""UTF-8"" ?><in />", Environment.NewLine);
+
+            const string xslt = @"<?xml version=""1.0""?>
+                                <xsl:stylesheet xmlns:xsl=""http://www.w3.org/1999/XSL/Transform"" version=""2.0"">
+                                <xsl:output method=""xml"" />
+                                <xsl:param name=""param"" />
+                                  <xsl:template match=""/in"">
+                                       <out><xsl:value-of select=""$param""/></out>
+                                  </xsl:template>
+                                </xsl:stylesheet>";
+
+            var res = Frends.Xml.Xml.Transform(new TransformInput() { Xml = transformXml, Xslt = xslt, XsltParameters = new XsltParameters[] { new XsltParameters { Name = "param" , Value = "foo" } } });
+            Assert.That(res, Is.EqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><out>foo</out>"));
         }
 
         [Test]

--- a/Frends.Xml.Tests/Tests.cs
+++ b/Frends.Xml.Tests/Tests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using NUnit.Framework;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json;
+using System.Text;
 
 namespace Frends.Xml.Tests
 {
@@ -132,9 +133,27 @@ namespace Frends.Xml.Tests
                                     <DIV>from <I><xsl:value-of select="".""/></I></DIV>
                                   </xsl:template>
                                 </xsl:stylesheet>";
-                
-           var res = Frends.Xml.Xml.Transform(new TransformInput() {Xml = transformXml, Xslt = xslt});
-           Assert.That(res,Is.EqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?>Hello, World!<DIV>from <I>An XSLT Programmer</I></DIV>"));
+
+            var res = Frends.Xml.Xml.Transform(new TransformInput() { Xml = transformXml, Xslt = xslt });
+            Assert.That(res, Is.EqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?>Hello, World!<DIV>from <I>An XSLT Programmer</I></DIV>"));
+        }
+
+
+        [Test]
+        public void TestXsltTransformWithNonUTF8Declaration()
+        {
+            const string transformXml = @"<?xml version=""1.0"" encoding=""Windows-1252"" ?><in>Ä</in>";
+
+            const string xslt = @"<?xml version=""1.0""?>
+                                <xsl:stylesheet xmlns:xsl=""http://www.w3.org/1999/XSL/Transform"" version=""2.0"">
+                                <xsl:output method=""xml"" />
+                                  <xsl:template match=""/in"">
+                                       <out><xsl:value-of select="".""/></out>
+                                  </xsl:template>
+                                </xsl:stylesheet>";
+
+            var res = Frends.Xml.Xml.Transform(new TransformInput() { Xml = transformXml, Xslt = xslt });
+            Assert.That(res, Is.EqualTo("<?xml version=\"1.0\" encoding=\"UTF-8\"?><out>Ä</out>"));
         }
 
         [Test]

--- a/Frends.Xml/Xml.cs
+++ b/Frends.Xml/Xml.cs
@@ -71,6 +71,7 @@ namespace Frends.Xml
                     XmlDocument xmldoc = new XmlDocument();
                     xmldoc.LoadXml(input.Xml);
                     xmldoc.Save(inputStream);
+                    xmldoc = null;
                     inputStream.Position = 0;
                     transformer.SetInputStream(inputStream, new Uri("file://"));
 

--- a/Frends.Xml/Xml.cs
+++ b/Frends.Xml/Xml.cs
@@ -63,9 +63,17 @@ namespace Frends.Xml
             {
                 var executable = compiler.Compile(stringReader);
                 var transformer = executable.Load();
-                using (var inputStream = new MemoryStream(Encoding.UTF8.GetBytes(input.Xml)))
+
+                
+                using (var inputStream = new MemoryStream())
                 {
+                    //XmlDocument always produces MemoryStream where its encoding matches the input XML's declaration
+                    XmlDocument xmldoc = new XmlDocument();
+                    xmldoc.LoadXml(input.Xml);
+                    xmldoc.Save(inputStream);
+                    inputStream.Position = 0;
                     transformer.SetInputStream(inputStream, new Uri("file://"));
+
                     input.XsltParameters?.ToList().ForEach(x => transformer.SetParameter(new QName(x.Name), new XdmAtomicValue(x.Value)));
 
                     using (var stringWriter = new StringWriter())


### PR DESCRIPTION
Transformer task had a bug when input XML string had XML declaration with non utf-8 value, e.g. \<?xml version="1.0" encoding="Windows-1252" ?>, because our implementation always passed it as utf-8 MemoryStream. 
To fix this the input XML is now passed through XmlDocument, because it automatically produces MemoryStream with correct encoding.

Added new unit test to test this case.

Previous workaround was to strip the XML declaration before passing the string to the task.
