### PR TITLE
Add option for additional namespaces

### DIFF
--- a/Frends.Xml.Tests/Tests.cs
+++ b/Frends.Xml.Tests/Tests.cs
@@ -117,6 +117,19 @@ namespace Frends.Xml.Tests
         }
         
         [Test]
+        public void TestXPathQueryWithAdditionalNamespace()
+        {
+            const string xPath = "fn:round(/bookstore/book[@genre='novel']/price)";
+            var res = Frends.Xml.Xml.XpathQuery(new QueryInput() { Xml = Xml, XpathQuery = xPath }, new QueryOptions()
+            {
+                XmlNamespaces = new XmlNamespace[] {new XmlNamespace { Prefix = "fn", Uri = "http://www.w3.org/2005/xpath-functions" } }
+            });
+            var jTokenRes = res.ToJson();
+            Assert.That(res.Data[0], Is.EqualTo(12.0d));
+            Assert.That(((JToken)jTokenRes[0]).Value<float>(), Is.EqualTo(12.0d));
+        }
+
+        [Test]
         public void TestXsltTransform()
         {
             const string transformXml = @"<?xml version=""1.0""?>

--- a/Frends.Xml/Definitions.cs
+++ b/Frends.Xml/Definitions.cs
@@ -41,6 +41,11 @@ namespace Frends.Xml
         /// XPath Query language version
         /// </summary>
         public XPathVersion XpathVersion { get; set; }
+
+        /// <summary>
+        /// XML namespaces to declare
+        /// </summary>
+        public XmlNamespace[] XmlNamespaces { get; set; }
     }
 
     public class QueryResults
@@ -181,5 +186,21 @@ namespace Frends.Xml
         /// The name for the root XML element
         /// </summary>
         public string XmlRootElementName { get; set; }
+    }
+
+    /// <summary>
+    /// XML namespace
+    /// </summary>
+    public class XmlNamespace
+    {
+        /// <summary>
+        /// Namespace prefix
+        /// </summary>
+        public string Prefix { get; set; }
+
+        /// <summary>
+        /// Namespace URI
+        /// </summary>
+        public string Uri { get; set; }
     }
 }

--- a/Frends.Xml/Xml.cs
+++ b/Frends.Xml/Xml.cs
@@ -157,6 +157,13 @@ namespace Frends.Xml
             builder.SchemaValidationMode = SchemaValidationMode.Lax;
 
             var xPathCompiler = proc.NewXPathCompiler();
+            if (options.XmlNamespaces != null)
+            {
+                foreach (XmlNamespace ns in options.XmlNamespaces)
+                {
+                    xPathCompiler.DeclareNamespace(ns.Prefix, ns.Uri);
+                }
+            }
 
             switch (options.XpathVersion)
             {


### PR DESCRIPTION
This change adds a new option for adding additional namespaces when doing XSL transform. This allows the use of function namespaces like www.w3.org/2005/xpath-functions to be used.